### PR TITLE
ansible-galaxy コマンドのローカル化とその他のユーティリティ周りに機能追加.

### DIFF
--- a/_scripts/req.txt
+++ b/_scripts/req.txt
@@ -1,2 +1,2 @@
-ansible==2.8.7
-Jinja2==2.10.3
+ansible-base>=2.10,<2.11
+Jinja2>=2.11,<2.12

--- a/_scripts/wrapper.sh
+++ b/_scripts/wrapper.sh
@@ -20,20 +20,6 @@ function readlink_f() {
     echo ${PHYS_DIR}/${TARGET_FILE}
 }
 
-# from: https://stackoverflow.com/questions/14366390/check-if-an-element-is-present-in-a-bash-array/14367368
-array_contains () {
-    local array="$1[@]"
-    local seeking="$2"
-    local in="no"
-    for element in "${!array}"; do
-        if [[ $element == "$seeking" ]]; then
-            in="yes";
-            break
-        fi
-    done
-    echo "${in}"
-}
-
 SCRIPT_PATH=$(readlink_f $0)
 SCRIPT_DIR=$(cd $(dirname ${SCRIPT_PATH}); pwd)
 
@@ -60,27 +46,14 @@ VENV_COLLECTIONS_PATH="${VENV_DIR}/share/ansible/collections"
 mkdir -p "${VENV_COLLECTIONS_PATH}"
 export ANSIBLE_COLLECTIONS_PATHS="${VENV_COLLECTIONS_PATH}:${DEFAULT_COLLECTIONS_PATHS}"
 
-## busybox のコマンド名とコマンドライン引数を取得
+## スクリプト名とコマンドライン引数を取得
 WRAPPER_CMD_NAME="$(basename ${0})"
 ARGS=("$@")
 
-## busybox のコマンド名 が wrapper.sh の時はここで終了.
+## スクリプト名 が wrapper.sh の時はここで終了.
 if [[ "${WRAPPER_CMD_NAME}" == "wrapper.sh" ]]; then
     exit 0;
 fi
 
-## busybox が特定のコマンド名の時, コマンドライン引数に一部修正を加える
-case "${WRAPPER_CMD_NAME}" in
-    "ansible-galaxy" )
-        ## コマンドライン引数に -p が指定されていない時は VENV_COLLECTIONS_PATH を指定する.
-        #  * 参照: https://docs.ansible.com/ansible/latest/galaxy/user_guide.html#installing-a-collection-from-galaxy
-        if [[ "$(array_contains ARGS '-p')" == "no" ]]; then
-            ARGS+=("-p" "${VENV_COLLECTIONS_PATH}")
-        fi
-        ;;
-
-    * ) ;;
-esac
-
-## シンボリック名に合わせて実行 busybox を実行
+## シンボリック名に合わせて実行このスクリプトを実行
 "${VENV_DIR}/bin/${WRAPPER_CMD_NAME}" "${ARGS[@]}"

--- a/_scripts/wrapper.sh
+++ b/_scripts/wrapper.sh
@@ -64,7 +64,7 @@ export ANSIBLE_COLLECTIONS_PATHS="${VENV_COLLECTIONS_PATH}:${DEFAULT_COLLECTIONS
 WRAPPER_CMD_NAME="$(basename ${0})"
 ARGS=("$@")
 
-## busybox のコマンド名 が install-ansible の時はここで終了.
+## busybox のコマンド名 が wrapper.sh の時はここで終了.
 if [[ "${WRAPPER_CMD_NAME}" == "wrapper.sh" ]]; then
     exit 0;
 fi

--- a/_scripts/wrapper.sh
+++ b/_scripts/wrapper.sh
@@ -2,37 +2,85 @@
 
 # from: https://qiita.com/edvakf@github/items/b8400f7dfe9210aadddd
 function readlink_f() {
-  local TARGET_FILE=$1
-  cd $(dirname ${TARGET_FILE})
-  TARGET_FILE=$(basename ${TARGET_FILE})
+    local TARGET_FILE=$1
+    cd $(dirname ${TARGET_FILE})
+    TARGET_FILE=$(basename ${TARGET_FILE})
 
-  # Iterate down a (possible) chain of symlinks
-  while [ -L "${TARGET_FILE}" ]
-  do
-      TARGET_FILE=$(readlink ${TARGET_FILE})
-      cd $(dirname ${TARGET_FILE})
-      TARGET_FILE=$(basename ${TARGET_FILE})
-  done
+    # Iterate down a (possible) chain of symlinks
+    while [ -L "${TARGET_FILE}" ]
+    do
+        TARGET_FILE=$(readlink ${TARGET_FILE})
+        cd $(dirname ${TARGET_FILE})
+        TARGET_FILE=$(basename ${TARGET_FILE})
+    done
 
-  # Compute the canonicalized name by finding the physical path
-  # for the directory we're in and appending the target file.
-  local PHYS_DIR=$(pwd -P)
-  echo ${PHYS_DIR}/${TARGET_FILE}
+    # Compute the canonicalized name by finding the physical path
+    # for the directory we're in and appending the target file.
+    local PHYS_DIR=$(pwd -P)
+    echo ${PHYS_DIR}/${TARGET_FILE}
+}
+
+# from: https://stackoverflow.com/questions/14366390/check-if-an-element-is-present-in-a-bash-array/14367368
+array_contains () {
+    local array="$1[@]"
+    local seeking="$2"
+    local in="no"
+    for element in "${!array}"; do
+        if [[ $element == "$seeking" ]]; then
+            in="yes";
+            break
+        fi
+    done
+    echo "${in}"
 }
 
 SCRIPT_PATH=$(readlink_f $0)
 SCRIPT_DIR=$(cd $(dirname ${SCRIPT_PATH}); pwd)
 
 if [ -e "${SCRIPT_DIR}/../../req.txt" ]; then
-  REQ_TXT="${SCRIPT_DIR}/../../req.txt"
+    REQ_TXT="${SCRIPT_DIR}/../../req.txt"
 else
-  REQ_TXT=${SCRIPT_DIR}/req.txt
+    REQ_TXT=${SCRIPT_DIR}/req.txt
 fi
 
 REQUIREMENT_HASH=$(cat ${REQ_TXT} | openssl dgst -md5 | sed 's/^.* //')
 VENV_DIR=$(cd ${SCRIPT_DIR}/../_venvs; pwd)/${REQUIREMENT_HASH}
 
+## python3-venv の作成とアクティベート
 bash ${SCRIPT_DIR}/prepare.sh ${VENV_DIR}
 source ${VENV_DIR}/bin/activate
 
-${VENV_DIR}/bin/$(basename $0) "$@"
+## ansible collections path の設定
+#  * VENV_COLLECTIONS_PATH を ANSIBLE_COLLECTIONS_PATHS の先頭に追加
+#  * VENV_COLLECTIONS_PATH ディレクトリを作成
+#  * ANSIBLE_COLLECTIONS_PATHS を環境変数としてエクスポート
+#  * 参照: https://docs.ansible.com/ansible/latest/reference_appendices/config.html#collections-paths
+DEFAULT_COLLECTIONS_PATHS="${HOME}/.ansible/collections:/usr/share/ansible/collections"
+VENV_COLLECTIONS_PATH="${VENV_DIR}/share/ansible/collections"
+mkdir -p "${VENV_COLLECTIONS_PATH}"
+export ANSIBLE_COLLECTIONS_PATHS="${VENV_COLLECTIONS_PATH}:${DEFAULT_COLLECTIONS_PATHS}"
+
+## busybox のコマンド名とコマンドライン引数を取得
+WRAPPER_CMD_NAME="$(basename ${0})"
+ARGS=("$@")
+
+## busybox のコマンド名 が install-ansible の時はここで終了.
+if [[ "${WRAPPER_CMD_NAME}" == "wrapper.sh" ]]; then
+    exit 0;
+fi
+
+## busybox が特定のコマンド名の時, コマンドライン引数に一部修正を加える
+case "${WRAPPER_CMD_NAME}" in
+    "ansible-galaxy" )
+        ## コマンドライン引数に -p が指定されていない時は VENV_COLLECTIONS_PATH を指定する.
+        #  * 参照: https://docs.ansible.com/ansible/latest/galaxy/user_guide.html#installing-a-collection-from-galaxy
+        if [[ "$(array_contains ARGS '-p')" == "no" ]]; then
+            ARGS+=("-p" "${VENV_COLLECTIONS_PATH}")
+        fi
+        ;;
+
+    * ) ;;
+esac
+
+## シンボリック名に合わせて実行 busybox を実行
+"${VENV_DIR}/bin/${WRAPPER_CMD_NAME}" "${ARGS[@]}"

--- a/ansible-config
+++ b/ansible-config
@@ -1,0 +1,1 @@
+_scripts/wrapper.sh

--- a/ansible-doc
+++ b/ansible-doc
@@ -1,0 +1,1 @@
+_scripts/wrapper.sh

--- a/clean_venvs.sh
+++ b/clean_venvs.sh
@@ -1,0 +1,9 @@
+#! /bin/bash -eu
+
+## リポジトリのルートディレクトリ
+REPO_DIR="$(cd $(dirname ${0}); pwd)"
+
+## _venvs の _venvs の中身を削除
+rm -rf "${REPO_DIR}/_venvs"
+mkdir -p "${REPO_DIR}/_venvs"
+touch "${REPO_DIR}/_venvs/.gitkeep"

--- a/install_ansible.sh
+++ b/install_ansible.sh
@@ -1,0 +1,7 @@
+#! /bin/bash -eu
+
+## リポジトリのルートディレクトリ
+REPO_DIR="$(cd $(dirname ${0}); pwd)"
+
+## ansible のインストール
+"${REPO_DIR}/_scripts/wrapper.sh"


### PR DESCRIPTION
@ledyba-z 
プルリクを投げさせてもらいました.
変更内容は以下にまとめてあります.
よろしくお願い致します!

## 変更点

* `_scripts/wrapper.sh` コマンドに以下の機能を追加.
  * 環境変数 `ANSIBLE_COLLECTIONS_PATHS` の用意. またその先頭に `${VENV_DIR}/share/ansible/collections` を追加
    (ansible-galaxy でインストールする collections のローカル化のため.
  * `wrapper.sh` そのもの (リンク経由ではなく) を実行した場合 ansible のインストールのみをする.
  * ↑の機能を使って, ansible をインストールする install_ansible.sh を用意.
    (このスクリプト内に ansible-galaxy コマンドを使って追加のモジュールをインストールなどできるように改変したい.)
* _venvs/ 以下をクリーンにする clean_venvs.sh を用意
* デフォルトの req.txt を以下のように変更
  * ansible から ansible-base に変更. バージョンは 2.10系に更新.
  * Jinja2 のバージョンを 2.11系に更新.

<br>

## ansible-galaxy の使い方例

### community.general のインストール

[community.general の HP](https://galaxy.ansible.com/community/general)

```
./ansible-galaxy collection install community.general
```

### community.zabbix のインストール

[community.zabbix の HP](https://galaxy.ansible.com/community/zabbix)

```
./ansible-galaxy collection install community.zabbix
```


<br>

## 参考

* https://docs.ansible.com/ansible/latest/reference_appendices/config.html#collections-paths
* https://docs.ansible.com/ansible/latest/galaxy/user_guide.html#installing-a-collection-from-galaxy
