### PR TITLE
Use latest pip and setuptools before pip install

### DIFF
--- a/_scripts/prepare.sh
+++ b/_scripts/prepare.sh
@@ -31,6 +31,7 @@ bash -eu <<EOF
   python3 -m venv ${VENV_DIR}
   source ${VENV_DIR}/bin/activate
 
+  pip3 install --upgrade pip setuptools
   pip3 install wheel
   pip3 install -r ${PRE_REQ_TXT}
   pip3 install -r ${REQ_TXT}


### PR DESCRIPTION
# EN_US
As reported [here](https://stackoverflow.com/questions/64919326/pip-error-installing-cryptography-on-big-sur), an error has been observed in MacOS Big Sur when installing the `cryptography` package using a pip prior to a certain version (possibly less than `21.0.1`). However several workarounds have already been suggested, the most simple solution is to use the latest pip. (According to the Stackoverflow above, this has been fixed in `21.0.1`.)

Although this solution is a kind of workaround, I suppose we could add the process of making sure the `pip` (and `setuptools`) is up to date before doing `pip install`. This is because the version of pip that comes by default when generating venv is slightly outdated and depends on the version of python used by pyenv and so on.

For your information, I have made this change to support versions of python less than 3.9, but it should be equivalent to the following for python 3.9.0 or later :)
```
python3 -m venv --upgrade-deps ${VENV_DIR}
```
# JA_JP
[こちら](https://stackoverflow.com/questions/64919326/pip-error-installing-cryptography-on-big-sur)で報告されているように、MacOS Big Surにおいて、特定のバージョン以前（おそらくは`21.0.1`未満）のpipを用いて`cryptography` パッケージをインストールする場合にエラーになるという事象が確認されています。
すでにいくつかのworkaroundが提案されていますが、最も簡単な解決策は最新のpipを用いることです。
（上記のStackoverflow によると`21.0.1`で修正されています）

最新のpipを用いるという方法はある種のworkaroundですが、venvの生成時にデフォルトで入るpipのバージョンが若干古い、かつ使用するpythonのバージョンに依存するという問題があるため、`pip`（とついでに`setuptools`）を最新にしてから `pip install` を行うという処理を加えても良いと考えています。

ちなみに、3.9未満のバージョンのpythonにも対応するためこのような変更にしていますが、python3.9以降であれば以下と等価なはずです。
```
python3 -m venv --upgrade-deps ${VENV_DIR}
```